### PR TITLE
Fix serverless integ test

### DIFF
--- a/src/sagemaker/predictor.py
+++ b/src/sagemaker/predictor.py
@@ -62,7 +62,7 @@ class PredictorBase(abc.ABC):
         """Perform inference on the provided data and return a prediction."""
 
     @abc.abstractmethod
-    def delete_endpoint(self, *args, **kwargs) -> None:
+    def delete_predictor(self, *args, **kwargs) -> None:
         """Destroy resources associated with this predictor."""
 
     @property
@@ -329,6 +329,8 @@ class Predictor(PredictorBase):
             self._delete_endpoint_config()
 
         self.sagemaker_session.delete_endpoint(self.endpoint_name)
+
+    delete_predictor = delete_endpoint
 
     def delete_model(self):
         """Deletes the Amazon SageMaker models backing this predictor."""

--- a/src/sagemaker/serverless/predictor.py
+++ b/src/sagemaker/serverless/predictor.py
@@ -61,7 +61,7 @@ class LambdaPredictor(PredictorBase):
             response["ResponseMetadata"]["HTTPHeaders"]["content-type"],
         )
 
-    def delete_endpoint(self) -> None:
+    def delete_predictor(self) -> None:
         """Destroy the Lambda function specified in the constructor."""
         self._client.delete_function(FunctionName=self._function_name)
 

--- a/tests/integ/test_serverless.py
+++ b/tests/integ/test_serverless.py
@@ -24,6 +24,8 @@ IMAGE_URI = "142577830533.dkr.ecr.us-west-2.amazonaws.com/serverless-integ-test:
 ROLE = "arn:aws:iam::142577830533:role/lambda_basic_execution"
 URL = "https://c.files.bbci.co.uk/12A9B/production/_111434467_gettyimages-1143489763.jpg"
 
+print('"CODEBUILD_BUILD_ID" in os.environ =', "CODEBUILD_BUILD_ID" in os.environ)
+
 
 @pytest.mark.skipif(
     "CODEBUILD_BUILD_ID" not in os.environ,
@@ -39,5 +41,5 @@ def test_lambda():
 
     assert prediction == {"class": "tabby"}
 
-    model.destroy()
-    predictor.destroy()
+    model.delete_model()
+    predictor.delete_predictor()

--- a/tests/unit/sagemaker/serverless/test_predictor.py
+++ b/tests/unit/sagemaker/serverless/test_predictor.py
@@ -48,7 +48,7 @@ def test_predict(mock_client):
 def test_delete_endpoint(mock_client):
     predictor = LambdaPredictor(FUNCTION_NAME, client=mock_client)
 
-    predictor.delete_endpoint()
+    predictor.delete_predictor()
 
     mock_client.delete_function.assert_called_once()
     _, kwargs = mock_client.delete_function.call_args


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/sagemaker-python-sdk/blob/master/CONTRIBUTING.md#committing-your-change)
- [ ] I have passed the region in to all S3 and STS clients that I've initialized as part of this change.
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/sagemaker-python-sdk/blob/master/README.rst) and [API docs](https://github.com/aws/sagemaker-python-sdk/tree/master/doc) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)
- [ ] I have used [`unique_name_from_base`](https://github.com/aws/sagemaker-python-sdk/blob/master/src/sagemaker/utils.py#L77) to create resource names in integ tests (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
